### PR TITLE
Avoid annoying logs

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -58,14 +58,14 @@ class fusioninventory::service inherits ::fusioninventory {
         ensure  => 'directory',
         owner   => 'root',
         group   => 'root',
-        mode    => '0750',
+        mode    => '0754',
         notify  => File['/etc/systemd/system/fusioninventory-agent.service.d/override.conf'],
       }
       file {'/etc/systemd/system/fusioninventory-agent.service.d/override.conf':
         ensure  => 'file',
         owner   => 'root',
         group   => 'root',
-        mode    => '0640',
+        mode    => '0644',
         content => template('fusioninventory/override.conf.erb'),
         notify  => Service[$pkgfusion],
         require => File['/etc/systemd/system/fusioninventory-agent.service.d/'],


### PR DESCRIPTION
Avoid having extra annoying log by allowing other to read the file: Configuration file /etc/systemd/system/fusioninventory-agent.service.d/override.conf is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.